### PR TITLE
Inline `Lockout` into `GcData`, saving an allocation

### DIFF
--- a/src/lockout.rs
+++ b/src/lockout.rs
@@ -16,58 +16,61 @@ pub struct Lockout {
 }
 
 impl Lockout {
-    pub fn new() -> Arc<Self> {
-        Arc::new(Self {
+    pub fn new() -> Self {
+        Self {
             count: AtomicU64::new(0),
             lockout_mutex: Mutex::new(()),
             lockout_condvar: Condvar::new(),
-        })
+        }
     }
 
-    pub fn get_warrant(self: &Arc<Self>) -> Warrant {
-        let starting_count = self.count.load(Ordering::SeqCst);
+    pub fn get_warrant<P: LockoutProvider>(provider: P) -> Warrant<P> {
+        let lockout = provider.provide();
+
+        let starting_count = lockout.count.load(Ordering::SeqCst);
 
         // Fast path, where the count is not SIGNPOSTED
         if starting_count != EXCLUSIVE_SIGNPOST {
-            let prev_value =
-                self.count
-                    .compare_and_swap(starting_count, starting_count + 1, Ordering::SeqCst);
+            let prev_value = lockout.count.compare_and_swap(
+                starting_count,
+                starting_count + 1,
+                Ordering::SeqCst,
+            );
             if prev_value == starting_count {
-                return Warrant {
-                    lockout: self.clone(),
-                };
+                return Warrant { provider };
             }
         }
 
         // Slow path, where we need to wait on a potential signposted val
-        let mut guard = self.lockout_mutex.lock();
+        let mut guard = lockout.lockout_mutex.lock();
         loop {
-            let value = self.count.load(Ordering::SeqCst);
+            let value = lockout.count.load(Ordering::SeqCst);
 
             if value == EXCLUSIVE_SIGNPOST {
-                self.lockout_condvar.wait(&mut guard);
+                lockout.lockout_condvar.wait(&mut guard);
             } else {
-                let prev_value = self
+                let prev_value = lockout
                     .count
                     .compare_and_swap(value, value + 1, Ordering::SeqCst);
                 if prev_value == value {
-                    return Warrant {
-                        lockout: self.clone(),
-                    };
+                    // Dropping the guard early is fine, the warrant has already been taken
+                    drop(guard);
+
+                    return Warrant { provider };
                 }
             }
         }
     }
 
-    pub fn get_exclusive_warrant(self: &Arc<Self>) -> Option<ExclusiveWarrant> {
-        let prev_value = self
+    pub fn get_exclusive_warrant<P: LockoutProvider>(provider: P) -> Option<ExclusiveWarrant<P>> {
+        let lockout = provider.provide();
+
+        let prev_value = lockout
             .count
             .compare_and_swap(0, EXCLUSIVE_SIGNPOST, Ordering::SeqCst);
 
         if prev_value == 0 {
-            Some(ExclusiveWarrant {
-                lockout: self.clone(),
-            })
+            Some(ExclusiveWarrant { provider })
         } else {
             None
         }
@@ -75,19 +78,20 @@ impl Lockout {
 }
 
 #[derive(Debug)]
-pub struct Warrant {
-    lockout: Arc<Lockout>,
+pub struct Warrant<P: LockoutProvider> {
+    provider: P,
 }
 
-impl Drop for Warrant {
+impl<P: LockoutProvider> Drop for Warrant<P> {
     fn drop(&mut self) {
         loop {
-            let count = self.lockout.count.load(Ordering::SeqCst);
+            let lockout = self.provider.provide();
+
+            let count = lockout.count.load(Ordering::SeqCst);
             assert!(count > 0 && count != EXCLUSIVE_SIGNPOST);
-            let prev_value =
-                self.lockout
-                    .count
-                    .compare_and_swap(count, count - 1, Ordering::SeqCst);
+            let prev_value = lockout
+                .count
+                .compare_and_swap(count, count - 1, Ordering::SeqCst);
             if prev_value == count {
                 return;
             }
@@ -96,46 +100,59 @@ impl Drop for Warrant {
 }
 
 #[derive(Debug)]
-pub struct ExclusiveWarrant {
-    lockout: Arc<Lockout>,
+pub struct ExclusiveWarrant<P: LockoutProvider> {
+    provider: P,
 }
 
-impl Drop for ExclusiveWarrant {
+impl<P: LockoutProvider> Drop for ExclusiveWarrant<P> {
     fn drop(&mut self) {
-        let _guard = self.lockout.lockout_mutex.lock();
-        let prev_count =
-            self.lockout
-                .count
-                .compare_and_swap(EXCLUSIVE_SIGNPOST, 0, Ordering::SeqCst);
+        let lockout = self.provider.provide();
+
+        let _guard = lockout.lockout_mutex.lock();
+        let prev_count = lockout
+            .count
+            .compare_and_swap(EXCLUSIVE_SIGNPOST, 0, Ordering::SeqCst);
         assert_eq!(prev_count, EXCLUSIVE_SIGNPOST);
-        self.lockout.lockout_condvar.notify_all();
+        lockout.lockout_condvar.notify_all();
+    }
+}
+
+pub trait LockoutProvider {
+    fn provide(&self) -> &Lockout;
+}
+
+impl LockoutProvider for Arc<Lockout> {
+    fn provide(&self) -> &Lockout {
+        &*self
     }
 }
 
 // TODO(issue): https://github.com/Others/shredder/issues/10
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+
     use super::Lockout;
 
     #[test]
     fn warrant_prevents_exclusive_warrant() {
-        let lockout = Lockout::new();
-        let _warrant = lockout.get_warrant();
-        let exclusive_warrant_option = lockout.get_exclusive_warrant();
+        let lockout = Arc::new(Lockout::new());
+        let _warrant = Lockout::get_warrant(lockout.clone());
+        let exclusive_warrant_option = Lockout::get_exclusive_warrant(lockout);
         assert!(exclusive_warrant_option.is_none());
     }
 
     #[test]
     fn exclusive_warrant_works_by_itself() {
-        let lockout = Lockout::new();
-        let exclusive_warrant_option = lockout.get_exclusive_warrant();
+        let lockout = Arc::new(Lockout::new());
+        let exclusive_warrant_option = Lockout::get_exclusive_warrant(lockout);
         assert!(exclusive_warrant_option.is_some());
     }
 
     #[test]
     fn multiple_warrants() {
-        let lockout = Lockout::new();
-        let _warrant_1 = lockout.get_warrant();
-        let _warrant_2 = lockout.get_warrant();
+        let lockout = Arc::new(Lockout::new());
+        let _warrant_1 = Lockout::get_warrant(lockout.clone());
+        let _warrant_2 = Lockout::get_warrant(lockout);
     }
 }

--- a/src/smart_ptr/mod.rs
+++ b/src/smart_ptr/mod.rs
@@ -8,8 +8,7 @@ use std::sync;
 
 use stable_deref_trait::StableDeref;
 
-use crate::collector::{InternalGcRef, COLLECTOR};
-use crate::lockout::Warrant;
+use crate::collector::{GcGuardWarrant, InternalGcRef, COLLECTOR};
 use crate::wrappers::{
     GcMutexGuard, GcPoisonError, GcRef, GcRefMut, GcRwLockReadGuard, GcRwLockWriteGuard,
     GcTryLockError,
@@ -251,7 +250,7 @@ where
 /// It exists as data needs protection from being scanned while it's being concurrently modified.
 pub struct GcGuard<'a, T: Scan> {
     gc_ptr: &'a Gc<T>,
-    _warrant: Warrant,
+    _warrant: GcGuardWarrant,
 }
 
 impl<'a, T: Scan> Deref for GcGuard<'a, T> {


### PR DESCRIPTION
This makes Gc::new a little faster, and may slightly reduce pointer chasing. 

Half of #28 