### PR TITLE
AtomicGc design and implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ shredder_derive = "0.1.1"
 stable_deref_trait = "1.1"
 
 [dev-dependencies]
-paste = "0.1"
+paste = "1.0"
 rand = "0.7.3"
 trybuild = "1.0"
 

--- a/check.fish
+++ b/check.fish
@@ -1,3 +1,3 @@
 #!/usr/bin/env fish
 cat (status -f)
-cargo fmt;and cargo clippy;and cargo audit;and cargo outdated;and cargo test --release
+cargo fmt;and cargo clippy;and cargo audit;and cargo update;and cargo outdated;and cargo test --release

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -1,0 +1,166 @@
+use std::marker::PhantomData;
+use std::mem;
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::Arc;
+
+use crate::collector::{GcData, InternalGcRef, COLLECTOR};
+use crate::{Gc, Scan};
+
+/// An atomic `Gc<T>`, useful for concurrent algorithms
+///
+/// This has more overhead than an `AtomicPtr`, but cleanly handles memory management. It also is
+/// similar to `Gc<T>` in that it can be cloned, and therefore easily shared.
+///
+/// `AtomicGc` should be fairly fast, but you may not assume it does not block. In fact in the
+/// presence of an active garbage collection operation, all operations will block.
+#[derive(Clone, Debug)]
+pub struct AtomicGc<T: Scan> {
+    atomic_ptr: Arc<AtomicPtr<GcData>>,
+    backing_handle: InternalGcRef,
+    _mark: PhantomData<Gc<T>>,
+}
+
+impl<T: Scan> AtomicGc<T> {
+    pub fn new(v: &Gc<T>) -> Self {
+        let _collection_blocker = COLLECTOR.get_atomic_guard_spinlock_inclusive();
+
+        let data = v.internal_handle_ref().data();
+        let data_ptr = Arc::into_raw(data);
+        let atomic_ptr = Arc::new(AtomicPtr::new(data_ptr as _));
+
+        Self {
+            atomic_ptr: atomic_ptr.clone(),
+            backing_handle: COLLECTOR.new_handle_for_atomic(atomic_ptr),
+            _mark: PhantomData,
+        }
+    }
+
+    pub(crate) fn internal_handle(&self) -> InternalGcRef {
+        self.backing_handle.clone()
+    }
+
+    #[must_use]
+    pub fn load(&self, ordering: Ordering) -> Gc<T> {
+        let ptr;
+        let internal_handle;
+        {
+            let _collection_blocker = COLLECTOR.get_atomic_guard_spinlock_inclusive();
+            let gc_data_ref = self.atomic_ptr.load(ordering);
+
+            // Safe since we know the collector is blocked
+            let gc_data_raw = unsafe { Arc::from_raw(gc_data_ref) };
+            let new_gc_data_ref = gc_data_raw.clone();
+            mem::forget(gc_data_raw);
+
+            ptr = new_gc_data_ref.scan_ptr().cast();
+            internal_handle = COLLECTOR.handle_from_data(new_gc_data_ref);
+        }
+
+        Gc::new_raw(internal_handle, ptr)
+    }
+
+    pub fn store(&self, v: &Gc<T>, ordering: Ordering) {
+        let data = v.internal_handle_ref().data();
+        let raw_data_ptr = Arc::into_raw(data);
+
+        {
+            let _collection_blocker = COLLECTOR.get_atomic_guard_spinlock_inclusive();
+            self.atomic_ptr.store(raw_data_ptr as _, ordering);
+        }
+    }
+
+    #[must_use]
+    pub fn swap(&self, v: &Gc<T>, ordering: Ordering) -> Gc<T> {
+        let data = v.internal_handle_ref().data();
+        let raw_data_ptr = Arc::into_raw(data);
+
+        let ptr;
+        let internal_handle;
+        {
+            let _collection_blocker = COLLECTOR.get_atomic_guard_spinlock_inclusive();
+            let old_data_ptr = self.atomic_ptr.swap(raw_data_ptr as _, ordering);
+
+            // Safe since we know the collector is blocked
+            let gc_data = unsafe { Arc::from_raw(old_data_ptr) };
+
+            ptr = gc_data.scan_ptr().cast();
+            internal_handle = COLLECTOR.handle_from_data(gc_data);
+        }
+
+        Gc::new_raw(internal_handle, ptr)
+    }
+
+    #[allow(clippy::must_use_candidate)]
+    pub fn compare_and_swap(&self, current: &Gc<T>, new: &Gc<T>, ordering: Ordering) -> bool {
+        let guess_data = current.internal_handle_ref().data();
+        let guess_data_raw = Arc::as_ptr(&guess_data) as _;
+
+        let new_data = new.internal_handle_ref().data();
+        let new_data_raw = Arc::into_raw(new_data) as _;
+
+        let compare_res;
+        {
+            let _collection_blocker = COLLECTOR.get_atomic_guard_spinlock_inclusive();
+            compare_res = self
+                .atomic_ptr
+                .compare_and_swap(guess_data_raw, new_data_raw, ordering);
+        }
+
+        if compare_res == guess_data_raw {
+            // The swap succeeded, and we need to take back ownership of the old data arc
+            unsafe {
+                Arc::from_raw(compare_res as *const GcData);
+            }
+            true
+        } else {
+            // The swap failed, and we need to take back ownership of the new data arc
+            unsafe {
+                Arc::from_raw(new_data_raw as *const GcData);
+            }
+            false
+        }
+    }
+
+    #[allow(clippy::must_use_candidate)]
+    pub fn compare_exchange(
+        &self,
+        current: &Gc<T>,
+        new: &Gc<T>,
+        success: Ordering,
+        failure: Ordering,
+    ) -> bool {
+        let guess_data = current.internal_handle_ref().data();
+        let guess_data_raw = Arc::as_ptr(&guess_data) as _;
+
+        let new_data = new.internal_handle_ref().data();
+        let new_data_raw = Arc::into_raw(new_data) as _;
+
+        let compare_res;
+        {
+            let _collection_blocker = COLLECTOR.get_atomic_guard_spinlock_inclusive();
+            compare_res =
+                self.atomic_ptr
+                    .compare_exchange(guess_data_raw, new_data_raw, success, failure);
+        }
+
+        if let Ok(old_ptr) = compare_res {
+            // The swap succeeded, and we need to take back ownership of the old data arc
+            unsafe {
+                Arc::from_raw(old_ptr as *const GcData);
+            }
+            true
+        } else {
+            // The swap failed, and we need to take back ownership of the new data arc
+            unsafe {
+                Arc::from_raw(new_data_raw as *const GcData);
+            }
+            false
+        }
+    }
+}
+
+impl<T: Scan> Drop for AtomicGc<T> {
+    fn drop(&mut self) {
+        self.backing_handle.invalidate();
+    }
+}

--- a/src/collector/alloc.rs
+++ b/src/collector/alloc.rs
@@ -9,7 +9,7 @@ use crate::{Finalize, Scan, Scanner};
 /// Represents a piece of data allocated by shredder
 #[derive(Copy, Clone, Debug, Hash)]
 pub struct GcAllocation {
-    scan_ptr: *const dyn Scan,
+    pub(crate) scan_ptr: *const dyn Scan,
     deallocation_action: DeallocationAction,
 }
 

--- a/src/collector/atomic_protection.rs
+++ b/src/collector/atomic_protection.rs
@@ -1,0 +1,84 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::thread::yield_now;
+
+const SENTINEL_VALUE: u64 = 1 << 60;
+
+pub struct AtomicProtectingSpinlock {
+    /// tracks who is holding the spinlock
+    /// if zero, no guards exists
+    /// if between zero and SENTINEL_VALUE, there are only inclusive guards
+    /// if between SENTINEL_VALUE and u64::max, there is only a single exclusive guard
+    tracker: AtomicU64,
+}
+
+impl AtomicProtectingSpinlock {
+    pub fn new() -> Self {
+        Self {
+            tracker: AtomicU64::new(0),
+        }
+    }
+
+    pub fn lock_exclusive(&self) -> APSExclusiveGuard<'_> {
+        // Standard spinlock stuff
+        loop {
+            // Load what the current situation is
+            let current_value = self.tracker.load(Ordering::Relaxed);
+
+            // We can only take an exclusive lock if the tracker zero (see self.tracker docs)
+            if current_value == 0 {
+                // Compare and swap to put the sentinel value in place
+                let prev = self
+                    .tracker
+                    .compare_and_swap(0, SENTINEL_VALUE, Ordering::Acquire);
+
+                // If we succeeded then we can return the guard, which will clean up after itself
+                if prev == 0 {
+                    return APSExclusiveGuard { parent: self };
+                }
+            }
+
+            // Try to be kind to our scheduler, even as we employ an anti-pattern
+            yield_now()
+        }
+    }
+
+    pub fn lock_inclusive(&self) -> Option<APSInclusiveGuard<'_>> {
+        // Greedily increment without checking if it's going to work
+        let old_value = self.tracker.fetch_add(1, Ordering::Acquire);
+        // If the old value is below the SENTINEL_VALUE, then we're free and clear
+        // (We assume SENTINEL_VALUE is so big, we'll never reach it by incrementing by 1)
+        if old_value < SENTINEL_VALUE {
+            Some(APSInclusiveGuard { parent: self })
+        } else {
+            None
+        }
+    }
+}
+
+impl Default for AtomicProtectingSpinlock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub struct APSExclusiveGuard<'a> {
+    parent: &'a AtomicProtectingSpinlock,
+}
+
+impl<'a> Drop for APSExclusiveGuard<'a> {
+    fn drop(&mut self) {
+        // Reset by sending us back to zero
+        self.parent.tracker.store(0, Ordering::Release);
+    }
+}
+
+pub struct APSInclusiveGuard<'a> {
+    parent: &'a AtomicProtectingSpinlock,
+}
+
+impl<'a> Drop for APSInclusiveGuard<'a> {
+    fn drop(&mut self) {
+        // Reset by subtracting 1
+        self.parent.tracker.fetch_sub(1, Ordering::Release);
+    }
+}

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -1,10 +1,11 @@
 mod alloc;
+mod atomic_protection;
 mod dropper;
 mod trigger;
 
 use std::cmp;
 use std::hash::{Hash, Hasher};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread::spawn;
 
@@ -17,6 +18,7 @@ use parking_lot::{Mutex, MutexGuard};
 use rayon::iter::{IntoParallelIterator, ParallelBridge, ParallelIterator};
 
 use crate::collector::alloc::GcAllocation;
+pub use crate::collector::atomic_protection::*;
 use crate::collector::dropper::{BackgroundDropper, DropMessage};
 use crate::collector::trigger::GcTrigger;
 use crate::lockout::{ExclusiveWarrant, Lockout, LockoutProvider, Warrant};
@@ -37,6 +39,14 @@ impl InternalGcRef {
     pub(crate) fn invalidate(&self) {
         COLLECTOR.drop_handle(self);
     }
+
+    pub(crate) fn data(&self) -> Arc<GcData> {
+        if let UnderlyingData::Fixed(data) = &self.handle_ref.underlying_data {
+            data.clone()
+        } else {
+            panic!("Only fixed data has a usable `data` method")
+        }
+    }
 }
 
 /// We don't want to expose what specific warrant provider we're using
@@ -52,6 +62,8 @@ pub struct Collector {
     monotonic_counter: AtomicU64,
     /// shredder only allows one collection to proceed at a time
     gc_lock: Mutex<()>,
+    /// this prevents atomic operations from happening during collection time
+    atomic_spinlock: AtomicProtectingSpinlock,
     /// trigger decides when we should run a collection
     trigger: GcTrigger,
     /// dropping happens in a background thread. This struct lets us communicate with that thread
@@ -78,7 +90,7 @@ struct TrackedData {
 
 /// Represents a piece of data tracked by the collector
 #[derive(Debug)]
-pub(crate) struct GcData {
+pub struct GcData {
     unique_id: u64,
     /// a wrapper to manage (ie deallocate) the underlying allocation
     underlying_allocation: GcAllocation,
@@ -89,6 +101,12 @@ pub(crate) struct GcData {
     // During what collection was this last marked?
     //     0 if this is a new piece of data
     last_marked: AtomicU64,
+}
+
+impl GcData {
+    pub(crate) fn scan_ptr(&self) -> *const dyn Scan {
+        self.underlying_allocation.scan_ptr
+    }
 }
 
 impl LockoutProvider for Arc<GcData> {
@@ -128,10 +146,30 @@ impl PartialOrd for GcData {
 pub(crate) struct GcHandle {
     unique_id: u64,
     /// what data is backing this handle
-    underlying_data: Arc<GcData>,
+    underlying_data: UnderlyingData,
     // During what collection was this last found in a piece of GcData?
     //     0 if this is a new piece of data
     last_non_rooted: AtomicU64,
+}
+
+#[derive(Debug)]
+pub enum UnderlyingData {
+    Fixed(Arc<GcData>),
+    DynamicForAtomic(Arc<AtomicPtr<GcData>>),
+}
+
+impl UnderlyingData {
+    // Safe only if called with an APS Exclusive guard
+    #[inline]
+    unsafe fn with_data<F: FnOnce(&GcData)>(&self, f: F) {
+        match self {
+            UnderlyingData::Fixed(data) => f(&*data),
+            UnderlyingData::DynamicForAtomic(ptr) => {
+                let arc_ptr = ptr.load(Ordering::Relaxed);
+                f(&*arc_ptr)
+            }
+        }
+    }
 }
 
 impl Hash for GcHandle {
@@ -169,6 +207,7 @@ impl Collector {
         let res = Arc::new(Self {
             monotonic_counter: AtomicU64::new(1),
             gc_lock: Mutex::default(),
+            atomic_spinlock: AtomicProtectingSpinlock::default(),
             trigger: GcTrigger::default(),
             dropper: BackgroundDropper::new(),
             async_gc_notifier,
@@ -250,7 +289,7 @@ impl Collector {
 
         let new_handle = Arc::new(GcHandle {
             unique_id: self.get_unique_id(),
-            underlying_data: new_data.clone(),
+            underlying_data: UnderlyingData::Fixed(new_data.clone()),
             last_non_rooted: AtomicU64::new(0),
         });
 
@@ -280,7 +319,35 @@ impl Collector {
     pub fn clone_handle(&self, handle: &InternalGcRef) -> InternalGcRef {
         let new_handle = Arc::new(GcHandle {
             unique_id: self.get_unique_id(),
-            underlying_data: handle.handle_ref.underlying_data.clone(),
+            underlying_data: UnderlyingData::Fixed(handle.data()),
+            last_non_rooted: AtomicU64::new(0),
+        });
+
+        self.tracked_data.handles.insert(new_handle.clone(), ());
+
+        InternalGcRef {
+            handle_ref: new_handle,
+        }
+    }
+
+    pub fn handle_from_data(&self, underlying_data: Arc<GcData>) -> InternalGcRef {
+        let new_handle = Arc::new(GcHandle {
+            unique_id: self.get_unique_id(),
+            underlying_data: UnderlyingData::Fixed(underlying_data),
+            last_non_rooted: AtomicU64::new(0),
+        });
+
+        self.tracked_data.handles.insert(new_handle.clone(), ());
+
+        InternalGcRef {
+            handle_ref: new_handle,
+        }
+    }
+
+    pub fn new_handle_for_atomic(&self, atomic_ptr: Arc<AtomicPtr<GcData>>) -> InternalGcRef {
+        let new_handle = Arc::new(GcHandle {
+            unique_id: self.get_unique_id(),
+            underlying_data: UnderlyingData::DynamicForAtomic(atomic_ptr),
             last_non_rooted: AtomicU64::new(0),
         });
 
@@ -295,17 +362,18 @@ impl Collector {
     pub fn get_data_warrant(&self, handle: &InternalGcRef) -> GcGuardWarrant {
         // This check is only necessary in the destructors
         // The destructor thread will always set the `deallocated` flag before deallocating data
-        let data_deallocated = handle
-            .handle_ref
-            .underlying_data
-            .deallocated
-            .load(Ordering::SeqCst);
-        if data_deallocated {
-            panic!("Tried to access into a Gc, but the internal state was corrupted (perhaps you're manipulating Gc<?> in a destructor?)");
-        }
+        if let UnderlyingData::Fixed(fixed) = &handle.handle_ref.underlying_data {
+            let data_deallocated = fixed.deallocated.load(Ordering::SeqCst);
 
-        GcGuardWarrant {
-            _warrant: Lockout::get_warrant(handle.handle_ref.underlying_data.clone()),
+            if data_deallocated {
+                panic!("Tried to access into a Gc, but the internal state was corrupted (perhaps you're manipulating Gc<?> in a destructor?)");
+            }
+
+            GcGuardWarrant {
+                _warrant: Lockout::get_warrant(fixed.clone()),
+            }
+        } else {
+            panic!("Cannot get data warrant for atomic data!")
         }
     }
 
@@ -333,6 +401,18 @@ impl Collector {
                 .expect("drop thread should be infallible!");
         }
         receiver.recv().expect("drop thread should be infallible!");
+    }
+
+    #[inline]
+    pub fn get_atomic_guard_spinlock_inclusive(&self) -> APSInclusiveGuard<'_> {
+        loop {
+            if let Some(inclusive_guard) = self.atomic_spinlock.lock_inclusive() {
+                return inclusive_guard;
+            }
+            // block on the collector if we can't get the APS guard
+            let collector_block = self.gc_lock.lock();
+            drop(collector_block);
+        }
     }
 
     pub fn check_then_collect(&self) -> bool {
@@ -369,6 +449,7 @@ impl Collector {
         // - Deleted handles cannot make the graph "more connected" if the deletion was not observed
 
         trace!("Beginning collection");
+        let _atomic_spinlock_guard = self.atomic_spinlock.lock_exclusive();
 
         let current_collection = self
             .tracked_data
@@ -434,35 +515,41 @@ impl Collector {
         // This step is dfs through the object graph (starting with the roots)
         // We mark each object we find
         let dfs_stack = DynQueue::new(roots);
-        dfs_stack.into_par_iter().for_each(|(queue, handle)| {
-            let data = &handle.underlying_data;
+        dfs_stack
+            .into_par_iter()
+            .for_each(|(queue, handle)| unsafe {
+                handle.underlying_data.with_data(|data| {
+                    // If this data is new, we don't want to `Scan` it, since we may not have its Lockout
+                    // Any handles inside this could not of been seen in step 1, so they'll be rooted anyway
+                    if data.last_marked.load(Ordering::SeqCst) != 0 {
+                        // Essential note! All non-new non-warranted data is automatically marked
+                        // Thus we will never accidentally scan non-warranted data here
+                        let previous_mark =
+                            data.last_marked.swap(current_collection, Ordering::SeqCst);
 
-            // If this data is new, we don't want to `Scan` it, since we may not have its Lockout
-            // Any handles inside this could not of been seen in step 1, so they'll be rooted anyway
-            if data.last_marked.load(Ordering::SeqCst) != 0 {
-                // Essential note! All non-new non-warranted data is automatically marked
-                // Thus we will never accidentally scan non-warranted data here
-                let previous_mark = data.last_marked.swap(current_collection, Ordering::SeqCst);
+                        // Since we've done an atomic swap, we know we've already scanned this iff it was marked
+                        // (excluding data marked because we couldn't get its warrant, who's handles would be seen as roots)
+                        // This stops us for scanning data more than once and, crucially, concurrently scanning the same data
+                        if previous_mark != current_collection {
+                            data.last_marked.store(current_collection, Ordering::SeqCst);
 
-                // Since we've done an atomic swap, we know we've already scanned this iff it was marked
-                // (excluding data marked because we couldn't get its warrant, who's handles would be seen as roots)
-                // This stops us for scanning data more than once and, crucially, concurrently scanning the same data
-                if previous_mark != current_collection {
-                    data.last_marked.store(current_collection, Ordering::SeqCst);
-
-                    data.underlying_allocation.scan(|h| {
-                        if h.handle_ref
-                            .underlying_data
-                            .last_marked
-                            .load(Ordering::SeqCst)
-                            != current_collection
-                        {
-                            queue.enqueue(h.handle_ref);
+                            data.underlying_allocation.scan(|h| {
+                                let mut should_enque = false;
+                                h.handle_ref.underlying_data.with_data(|scanned_data| {
+                                    if scanned_data.last_marked.load(Ordering::SeqCst)
+                                        != current_collection
+                                    {
+                                        should_enque = true;
+                                    }
+                                });
+                                if should_enque {
+                                    queue.enqueue(h.handle_ref);
+                                }
+                            });
                         }
-                    });
-                }
-            }
-        });
+                    }
+                })
+            });
         // We're done scanning things, and have established what is marked. Release the warrants
         drop(warrants);
 
@@ -540,13 +627,13 @@ pub(crate) fn get_mock_handle() -> InternalGcRef {
     // Note: Here we assume a random u64 is unique. That's hacky, but is fine for testing :)
     InternalGcRef::new(Arc::new(GcHandle {
         unique_id: rand::random(),
-        underlying_data: Arc::new(GcData {
+        underlying_data: UnderlyingData::Fixed(Arc::new(GcData {
             unique_id: rand::random(),
             underlying_allocation: unsafe { GcAllocation::raw(Box::into_raw(mock_scannable)) },
             lockout: Lockout::new(),
             deallocated: AtomicBool::new(false),
             last_marked: AtomicU64::new(0),
-        }),
+        })),
         last_non_rooted: AtomicU64::new(0),
     }))
 }

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -404,7 +404,7 @@ impl Collector {
     }
 
     #[inline]
-    pub fn get_atomic_guard_spinlock_inclusive(&self) -> APSInclusiveGuard<'_> {
+    pub fn get_collection_blocker_spinlock(&self) -> APSInclusiveGuard<'_> {
         loop {
             if let Some(inclusive_guard) = self.atomic_spinlock.lock_inclusive() {
                 return inclusive_guard;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,8 @@
 //! - no no-std support: The collector requires threading and other `std` features (will fix!)
 
 // We love docs here
-#![deny(missing_docs)]
+// #![deny(missing_docs)]
+
 // Clippy configuration:
 // I'd like the most pedantic warning level
 #![warn(
@@ -49,6 +50,8 @@ extern crate log;
 #[macro_use]
 extern crate rental;
 
+/// Atomic gc operations
+pub mod atomic;
 mod collector;
 mod finalize;
 mod lockout;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,8 +22,7 @@
 //! - no no-std support: The collector requires threading and other `std` features (will fix!)
 
 // We love docs here
-// #![deny(missing_docs)]
-
+#![deny(missing_docs)]
 // Clippy configuration:
 // I'd like the most pedantic warning level
 #![warn(

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -8,6 +8,7 @@ use std::ops::{Deref, DerefMut};
 use crate::collector::InternalGcRef;
 use crate::Gc;
 
+use crate::atomic::AtomicGc;
 pub use helper::EmptyScan;
 pub use r::{RMut, R};
 
@@ -141,8 +142,8 @@ impl<'a> Scanner<'a> {
     #[doc(hidden)]
     pub fn check_gc_safe<T: GcSafe>(&self, _: &T) {}
 
-    fn add_internal_handle<T: Scan>(&mut self, gc: &Gc<T>) {
-        (self.scan_callback)(gc.internal_handle());
+    fn add_internal_handle(&mut self, gc_ref: InternalGcRef) {
+        (self.scan_callback)(gc_ref);
     }
 }
 
@@ -152,10 +153,19 @@ unsafe impl<T: Scan> Scan for Gc<T> {
     #[allow(clippy::inline_always)]
     #[inline(always)]
     fn scan(&self, scanner: &mut Scanner<'_>) {
-        scanner.add_internal_handle(self)
+        scanner.add_internal_handle(self.internal_handle());
     }
 }
 unsafe impl<T: Scan> GcSafe for Gc<T> {}
+
+// Another fundamental implementation
+unsafe impl<T: Scan> Scan for AtomicGc<T> {
+    fn scan(&self, scanner: &mut Scanner<'_>) {
+        scanner.add_internal_handle(self.internal_handle());
+    }
+}
+
+unsafe impl<T: Scan> GcSafe for AtomicGc<T> {}
 
 /// `GcSafeWrapper` wraps a `Send` datatype to make it `GcSafe`
 /// See the documentation of `Send` to see where this would be useful

--- a/src/smart_ptr/mod.rs
+++ b/src/smart_ptr/mod.rs
@@ -75,6 +75,13 @@ impl<T: Scan> Gc<T> {
         }
     }
 
+    pub(crate) fn new_raw(backing_handle: InternalGcRef, direct_ptr: *const T) -> Self {
+        Self {
+            backing_handle,
+            direct_ptr,
+        }
+    }
+
     /// `get` lets you get a `GcGuard`, which will deref to the underlying data.
     ///
     /// `get` is used to get a `GcGuard`. This is usually what you want when accessing non-`Sync`
@@ -91,6 +98,10 @@ impl<T: Scan> Gc<T> {
 
     pub(crate) fn internal_handle(&self) -> InternalGcRef {
         self.backing_handle.clone()
+    }
+
+    pub(crate) fn internal_handle_ref(&self) -> &InternalGcRef {
+        &self.backing_handle
     }
 }
 


### PR DESCRIPTION
Adds Atomic support to shredder! The atomic operations should be
fairly fast, but obviously need to do some Gc related book
keeping. Also they block if collection is happening, which may be
inevitible. Perhaps we could lift this limitation for reads?

I think this is the right design--I've thought a lot about other
ways to do this and this was the only fruitful one.

Still missing docs and tests, but wanted to put this up to solicit
feedback.