### PR TITLE
Batch destructors, make AtomicGc operations unsafe for now

### DIFF
--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -20,7 +20,6 @@ use crate::{Gc, Scan};
 #[derive(Clone, Debug)]
 pub struct AtomicGc<T: Scan> {
     // It is only safe to read the data here if a collection is not happening
-    // Only safe to write a pointer gotten from `Arc::into_raw`
     atomic_ptr: Arc<AtomicPtr<GcData>>,
     backing_handle: InternalGcRef,
     _mark: PhantomData<Gc<T>>,
@@ -32,12 +31,15 @@ impl<T: Scan> AtomicGc<T> {
     /// The created `AtomicGc` will point to the same data as `data`
     #[must_use]
     pub fn new(data: &Gc<T>) -> Self {
+        // Ensure we don't create an atomic out of dead data...
+        data.assert_live();
+
         // `data` is guaranteed to be pointing to the data we're about to contain, so we don't need to
         // worry about data getting cleaned up (and therefore we don't need to block the collector)
 
         // Carefully craft a ptr to store atomically
         let data_arc = data.internal_handle_ref().data();
-        let data_ptr = Arc::into_raw(data_arc);
+        let data_ptr = Arc::as_ptr(data_arc);
 
         let atomic_ptr = Arc::new(AtomicPtr::new(data_ptr as _));
 
@@ -55,21 +57,26 @@ impl<T: Scan> AtomicGc<T> {
     /// `load` the data from this `AtomicGc<T>`, getting back a `Gc<T>`
     ///
     /// The ordering/atomicity guarantees are identical to `AtomicPtr::load`
+    ///
+    /// # Safety
+    /// Must not be called from a Gc<T> destructor! Also you may not load from an atomic storing
+    /// data that has been deallocated. (Only possible if you send a `AtomicGc` out of the
+    /// background thread somehow.)
     #[must_use]
-    pub fn load(&self, ordering: Ordering) -> Gc<T> {
+    pub unsafe fn load(&self, ordering: Ordering) -> Gc<T> {
         let ptr;
         let internal_handle;
         {
             let _collection_blocker = COLLECTOR.get_collection_blocker_spinlock();
 
             // Safe to manipulate this ptr only because we have the `_collection_blocker`
-            let gc_data_ref = self.atomic_ptr.load(ordering);
-            let gc_data_raw = unsafe { Arc::from_raw(gc_data_ref) };
+            let gc_data_ptr = self.atomic_ptr.load(ordering);
+            let gc_data_temp = Arc::from_raw(gc_data_ptr);
 
             // Create a new `Arc` pointing to the same data, but don't invalidate the existing `Arc`
             // (which is effectively "behind" the pointer)
-            let new_gc_data_ref = gc_data_raw.clone();
-            mem::forget(gc_data_raw);
+            let new_gc_data_ref = gc_data_temp.clone();
+            mem::forget(gc_data_temp);
 
             ptr = new_gc_data_ref.scan_ptr().cast();
             internal_handle = COLLECTOR.handle_from_data(new_gc_data_ref);
@@ -80,30 +87,42 @@ impl<T: Scan> AtomicGc<T> {
 
     /// `store` new data into this `AtomicGc`
     ///
-    /// The ordering/atomicity guarantees are identical to `AtomicPtr::swap`
-    pub fn store(&self, v: &Gc<T>, ordering: Ordering) {
+    /// The ordering/atomicity guarantees are identical to `AtomicPtr::store`
+    ///
+    /// # Safety
+    /// Must not be called from a Gc<T> destructor! Also you may not load from an atomic storing
+    /// data that has been deallocated. (Only possible if you send a `AtomicGc` out of the
+    /// background thread somehow.)
+    pub unsafe fn store(&self, v: &Gc<T>, ordering: Ordering) {
+        // Ensure we're not storing dead data...
+        v.assert_live();
+
         let data = v.internal_handle_ref().data();
-        let raw_data_ptr = Arc::into_raw(data);
+        let raw_data_ptr = Arc::as_ptr(data);
 
         {
             let _collection_blocker = COLLECTOR.get_collection_blocker_spinlock();
 
             // Safe to manipulate this ptr only because we have the `_collection_blocker`
-            let old_ptr = self.atomic_ptr.swap(raw_data_ptr as _, ordering);
-
-            // Must cleanup old ptr
-            let old_arc = unsafe { Arc::from_raw(old_ptr) };
-            drop(old_arc);
+            self.atomic_ptr.store(raw_data_ptr as _, ordering);
         }
     }
 
     /// `swap` what data is stored in this `AtomicGc`, getting a `Gc` to the old data back
     ///
     /// The ordering/atomicity guarantees are identical to `AtomicPtr::swap`
+    ///
+    /// # Safety
+    /// Must not be called from a Gc<T> destructor! Also you may not load from an atomic storing
+    /// data that has been deallocated. (Only possible if you send a `AtomicGc` out of the
+    /// background thread somehow.)
     #[must_use]
-    pub fn swap(&self, v: &Gc<T>, ordering: Ordering) -> Gc<T> {
+    pub unsafe fn swap(&self, v: &Gc<T>, ordering: Ordering) -> Gc<T> {
+        // Ensure we're not storing dead data...
+        v.assert_live();
+
         let data = v.internal_handle_ref().data();
-        let raw_data_ptr = Arc::into_raw(data);
+        let raw_data_ptr = Arc::as_ptr(data);
 
         let ptr;
         let internal_handle;
@@ -112,7 +131,9 @@ impl<T: Scan> AtomicGc<T> {
             let old_data_ptr = self.atomic_ptr.swap(raw_data_ptr as _, ordering);
 
             // Safe since we know the collector is blocked
-            let gc_data = unsafe { Arc::from_raw(old_data_ptr) };
+            let old_data_arc = Arc::from_raw(old_data_ptr);
+            let gc_data = old_data_arc.clone();
+            mem::forget(old_data_arc);
 
             ptr = gc_data.scan_ptr().cast();
             internal_handle = COLLECTOR.handle_from_data(gc_data);
@@ -132,15 +153,28 @@ impl<T: Scan> AtomicGc<T> {
     /// # Returns
     /// Returns `true` if the swap happened and this `AtomicGc` now points to `new`
     /// Returns `false` if the swap failed / this `AtomicGc` was not pointing to `current`
+    ///
+    /// # Safety
+    /// Must not be called from a Gc<T> destructor! Also you may not load from an atomic storing
+    /// data that has been deallocated. (Only possible if you send a `AtomicGc` out of the
+    /// background thread somehow.)
     #[allow(clippy::must_use_candidate)]
-    pub fn compare_and_swap(&self, current: &Gc<T>, new: &Gc<T>, ordering: Ordering) -> bool {
+    pub unsafe fn compare_and_swap(
+        &self,
+        current: &Gc<T>,
+        new: &Gc<T>,
+        ordering: Ordering,
+    ) -> bool {
+        // Ensure we're not storing dead data...
+        new.assert_live();
+
         // Turn guess data into a raw ptr
         let guess_data = current.internal_handle_ref().data();
-        let guess_data_raw = Arc::as_ptr(&guess_data) as _;
+        let guess_data_raw = Arc::as_ptr(guess_data) as _;
 
         // Turn new data into a raw ptr
         let new_data = new.internal_handle_ref().data();
-        let new_data_raw = Arc::into_raw(new_data) as _;
+        let new_data_raw = Arc::as_ptr(new_data) as _;
 
         let compare_res;
         {
@@ -151,19 +185,7 @@ impl<T: Scan> AtomicGc<T> {
                 .compare_and_swap(guess_data_raw, new_data_raw, ordering);
         }
 
-        if compare_res == guess_data_raw {
-            // The swap succeeded, and we need to take back ownership of the old data arc
-            unsafe {
-                Arc::from_raw(compare_res as *const GcData);
-            }
-            true
-        } else {
-            // The swap failed, and we need to take back ownership of the new data arc
-            unsafe {
-                Arc::from_raw(new_data_raw as *const GcData);
-            }
-            false
-        }
+        compare_res == guess_data_raw
     }
 
     /// Do a CAE operation. If this `AtomicGc` points to the same data as `current` then after this
@@ -178,19 +200,27 @@ impl<T: Scan> AtomicGc<T> {
     /// # Returns
     /// Returns `true` if the swap happened and this `AtomicGc` now points to `new`
     /// Returns `false` if the swap failed / this `AtomicGc` was not pointing to `current`
+    ///
+    /// # Safety
+    /// Must not be called from a Gc<T> destructor! Also you may not load from an atomic storing
+    /// data that has been deallocated. (Only possible if you send a `AtomicGc` out of the
+    /// background thread somehow.)
     #[allow(clippy::must_use_candidate)]
-    pub fn compare_exchange(
+    pub unsafe fn compare_exchange(
         &self,
         current: &Gc<T>,
         new: &Gc<T>,
         success: Ordering,
         failure: Ordering,
     ) -> bool {
+        // Ensure we're not storing dead data...
+        new.assert_live();
+
         let guess_data = current.internal_handle_ref().data();
-        let guess_data_raw = Arc::as_ptr(&guess_data) as _;
+        let guess_data_raw = Arc::as_ptr(guess_data) as _;
 
         let new_data = new.internal_handle_ref().data();
-        let new_data_raw = Arc::into_raw(new_data) as _;
+        let new_data_raw = Arc::as_ptr(new_data) as _;
 
         let compare_res;
         {
@@ -200,19 +230,7 @@ impl<T: Scan> AtomicGc<T> {
                     .compare_exchange(guess_data_raw, new_data_raw, success, failure);
         }
 
-        if let Ok(old_ptr) = compare_res {
-            // The swap succeeded, and we need to take back ownership of the old data arc
-            unsafe {
-                Arc::from_raw(old_ptr as *const GcData);
-            }
-            true
-        } else {
-            // The swap failed, and we need to take back ownership of the new data arc
-            unsafe {
-                Arc::from_raw(new_data_raw as *const GcData);
-            }
-            false
-        }
+        compare_res.is_ok()
     }
 
     // TODO: Compare and swap/compare and exchange that return the current value
@@ -222,8 +240,5 @@ impl<T: Scan> Drop for AtomicGc<T> {
     fn drop(&mut self) {
         // Manually cleanup the backing handle...
         self.backing_handle.invalidate();
-        // Manually cleanup the `Arc` inside the `atomic_ptr`
-        let ptr = self.atomic_ptr.load(Ordering::Relaxed);
-        drop(unsafe { Arc::from_raw(ptr) });
     }
 }

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -38,9 +38,9 @@ impl InternalGcRef {
         COLLECTOR.drop_handle(self);
     }
 
-    pub(crate) fn data(&self) -> Arc<GcData> {
+    pub(crate) fn data(&self) -> &Arc<GcData> {
         if let UnderlyingData::Fixed(data) = &self.handle_ref.v.underlying_data {
-            data.clone()
+            data
         } else {
             panic!("Only fixed data has a usable `data` method")
         }
@@ -201,7 +201,7 @@ impl Collector {
 
     pub fn clone_handle(&self, handle: &InternalGcRef) -> InternalGcRef {
         let new_handle_arc = Arc::new(GcHandle {
-            underlying_data: UnderlyingData::Fixed(handle.data()),
+            underlying_data: UnderlyingData::Fixed(handle.data().clone()),
             last_non_rooted: AtomicU64::new(0),
         });
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -226,100 +226,108 @@ fn no_drop_functional() {
 
 #[test]
 fn simple_atomic_cleanup() {
-    let _guard = TEST_MUTEX.lock();
+    unsafe {
+        let _guard = TEST_MUTEX.lock();
 
-    run_with_gc_cleanup(|| {
-        let value = Gc::new(17);
-        let atomic = AtomicGc::new(&value);
-        drop(value);
+        run_with_gc_cleanup(|| {
+            let value = Gc::new(17);
+            let atomic = AtomicGc::new(&value);
+            drop(value);
 
-        let fr = atomic.load(Ordering::Relaxed);
-        assert_eq!(*fr.get(), 17);
-        drop(fr);
+            let fr = atomic.load(Ordering::Relaxed);
+            assert_eq!(*fr.get(), 17);
+            drop(fr);
 
-        let new_value = Gc::new(20);
-        atomic.store(&new_value, Ordering::Relaxed);
-        drop(new_value);
+            let new_value = Gc::new(20);
+            atomic.store(&new_value, Ordering::Relaxed);
+            drop(new_value);
 
-        let sr = atomic.load(Ordering::Relaxed);
-        assert_eq!(*sr.get(), 20);
-        drop(sr);
+            let sr = atomic.load(Ordering::Relaxed);
+            assert_eq!(*sr.get(), 20);
+            drop(sr);
 
-        collect();
-        assert_eq!(number_of_tracked_allocations(), 1);
-    });
-    assert_eq!(number_of_tracked_allocations(), 0);
+            collect();
+            assert_eq!(number_of_tracked_allocations(), 1);
+        });
+        assert_eq!(number_of_tracked_allocations(), 0);
+    }
 }
 
 #[test]
 fn atomic_cycle() {
-    let _guard = TEST_MUTEX.lock();
-    run_with_gc_cleanup(|| {
-        let a = Gc::new(sync::Mutex::new(Connection { connect: None }));
+    unsafe {
+        let _guard = TEST_MUTEX.lock();
+        run_with_gc_cleanup(|| {
+            let a = Gc::new(sync::Mutex::new(Connection { connect: None }));
 
-        let b = Gc::new(sync::Mutex::new(Connection { connect: None }));
+            let b = Gc::new(sync::Mutex::new(Connection { connect: None }));
 
-        let a_atomic = AtomicGc::new(&a);
-        let b_atomic = AtomicGc::new(&b);
-        drop(a);
-        drop(b);
+            let a_atomic = AtomicGc::new(&a);
+            let b_atomic = AtomicGc::new(&b);
+            drop(a);
+            drop(b);
 
-        let a_read = a_atomic.load(Ordering::Relaxed);
-        let b_read = b_atomic.load(Ordering::Relaxed);
+            let a_read = a_atomic.load(Ordering::Relaxed);
+            let b_read = b_atomic.load(Ordering::Relaxed);
 
-        let mut a_guard = a_read.lock().unwrap();
-        let mut b_guard = b_read.lock().unwrap();
+            let mut a_guard = a_read.lock().unwrap();
+            let mut b_guard = b_read.lock().unwrap();
 
-        a_guard.connect = Some(b_read.clone());
-        b_guard.connect = Some(a_read.clone());
-    });
+            a_guard.connect = Some(b_read.clone());
+            b_guard.connect = Some(a_read.clone());
+        });
 
-    assert_eq!(number_of_tracked_allocations(), 0);
+        assert_eq!(number_of_tracked_allocations(), 0);
+    }
 }
 
 #[test]
 fn atomic_compare_and_swap_test() {
-    let _guard = TEST_MUTEX.lock();
-    run_with_gc_cleanup(|| {
-        let v1 = Gc::new(123);
-        let v2 = Gc::new(1776);
-        let v1_alt = Gc::new(123);
+    unsafe {
+        let _guard = TEST_MUTEX.lock();
+        run_with_gc_cleanup(|| {
+            let v1 = Gc::new(123);
+            let v2 = Gc::new(1776);
+            let v1_alt = Gc::new(123);
 
-        let atomic = AtomicGc::new(&v1);
-        assert_eq!(*atomic.load(Ordering::Relaxed).get(), 123);
+            let atomic = AtomicGc::new(&v1);
+            assert_eq!(*atomic.load(Ordering::Relaxed).get(), 123);
 
-        let res = atomic.compare_and_swap(&v1, &v2, Ordering::Relaxed);
-        assert!(res);
-        assert_eq!(*atomic.load(Ordering::Relaxed).get(), 1776);
+            let res = atomic.compare_and_swap(&v1, &v2, Ordering::Relaxed);
+            assert!(res);
+            assert_eq!(*atomic.load(Ordering::Relaxed).get(), 1776);
 
-        atomic.store(&v1, Ordering::Relaxed);
-        let res = atomic.compare_and_swap(&v1_alt, &v2, Ordering::Relaxed);
-        assert!(!res);
-        assert_eq!(*atomic.load(Ordering::Relaxed).get(), 123);
-    });
-    assert_eq!(number_of_tracked_allocations(), 0);
+            atomic.store(&v1, Ordering::Relaxed);
+            let res = atomic.compare_and_swap(&v1_alt, &v2, Ordering::Relaxed);
+            assert!(!res);
+            assert_eq!(*atomic.load(Ordering::Relaxed).get(), 123);
+        });
+        assert_eq!(number_of_tracked_allocations(), 0);
+    }
 }
 
 #[test]
 fn atomic_compare_and_exchange_test() {
-    let _guard = TEST_MUTEX.lock();
-    run_with_gc_cleanup(|| {
-        let v1 = Gc::new(123);
-        let v2 = Gc::new(1776);
-        let v1_alt = Gc::new(123);
+    unsafe {
+        let _guard = TEST_MUTEX.lock();
+        run_with_gc_cleanup(|| {
+            let v1 = Gc::new(123);
+            let v2 = Gc::new(1776);
+            let v1_alt = Gc::new(123);
 
-        let atomic = AtomicGc::new(&v1);
-        assert_eq!(*atomic.load(Ordering::Relaxed).get(), 123);
+            let atomic = AtomicGc::new(&v1);
+            assert_eq!(*atomic.load(Ordering::Relaxed).get(), 123);
 
-        let res = atomic.compare_exchange(&v1, &v2, Ordering::Relaxed, Ordering::Relaxed);
-        assert!(res);
-        assert_eq!(*atomic.load(Ordering::Relaxed).get(), 1776);
+            let res = atomic.compare_exchange(&v1, &v2, Ordering::Relaxed, Ordering::Relaxed);
+            assert!(res);
+            assert_eq!(*atomic.load(Ordering::Relaxed).get(), 1776);
 
-        atomic.store(&v1, Ordering::Relaxed);
-        let res = atomic.compare_exchange(&v1_alt, &v2, Ordering::Relaxed, Ordering::Relaxed);
-        assert!(!res);
-        assert_eq!(*atomic.load(Ordering::Relaxed).get(), 123);
-    });
-    assert_eq!(number_of_tracked_allocations(), 0);
-    assert_eq!(number_of_active_handles(), 0);
+            atomic.store(&v1, Ordering::Relaxed);
+            let res = atomic.compare_exchange(&v1_alt, &v2, Ordering::Relaxed, Ordering::Relaxed);
+            assert!(!res);
+            assert_eq!(*atomic.load(Ordering::Relaxed).get(), 123);
+        });
+        assert_eq!(number_of_tracked_allocations(), 0);
+        assert_eq!(number_of_active_handles(), 0);
+    }
 }


### PR DESCRIPTION
This fixes a couple of soundness holes. (Minor in scope, only
observable in the face of some pretty adverserial code.)

Next patch in this series will fix the unsafety of AtomicGc, and
implement DerefGc!