### PR TITLE
Add EmptyScan impl for bool

### DIFF
--- a/src/scan/std_impls.rs
+++ b/src/scan/std_impls.rs
@@ -145,6 +145,8 @@ unsafe impl<T: Scan + ?Sized> Scan for RwLock<T> {
 unsafe impl<T: GcSafe + ?Sized> GcSafe for RwLock<T> {}
 
 // Primitives do not hold any Gc<T>s
+impl EmptyScan for bool {}
+
 impl EmptyScan for isize {}
 impl EmptyScan for usize {}
 


### PR DESCRIPTION
I've been using the library for a small personal project, and I just noticed that bool values are not `EmptyScan`.