### PR TITLE
Bump crossbeam and dynqueue versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2018"
 
 [dependencies]
 arc-swap = "0.4.7"
-crossbeam = "0.7.3"
-dynqueue = { version = "0.1.3", features = ["crossbeam-queue"] }
+crossbeam = "0.8.0"
+dynqueue = { version = "0.3.0", features = ["crossbeam-queue"] }
 log = "0.4.8"
 once_cell = "1.4"
 parking_lot = "0.11.0"

--- a/src/collector/collect_impl.rs
+++ b/src/collector/collect_impl.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::Ordering;
 
 use crossbeam::deque::Injector;
 use crossbeam::queue::SegQueue;
-use dynqueue::DynQueue;
+use dynqueue::IntoDynQueue;
 use parking_lot::{MutexGuard, RwLock};
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 
@@ -79,7 +79,7 @@ impl Collector {
 
         // This step is dfs through the object graph (starting with the roots)
         // We mark each object we find
-        let dfs_stack = DynQueue::new(roots);
+        let dfs_stack = roots.into_dyn_queue();
         dfs_stack
             .into_par_iter()
             .for_each(|(queue, handle)| unsafe {

--- a/src/collector/dropper.rs
+++ b/src/collector/dropper.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread::spawn;
 
-use crossbeam::{SendError, Sender};
+use crossbeam::channel::{self, SendError, Sender};
 use parking_lot::RwLock;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
@@ -23,7 +23,7 @@ pub(crate) enum DropMessage {
 
 impl BackgroundDropper {
     pub fn new() -> Self {
-        let (sender, receiver) = crossbeam::unbounded();
+        let (sender, receiver) = channel::unbounded();
 
         // The drop thread deals with doing all the Drops this collector needs to do
         spawn(move || {

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -8,7 +8,7 @@ use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread::spawn;
 
-use crossbeam::Sender;
+use crossbeam::channel::{self, Sender};
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 
@@ -88,7 +88,7 @@ struct TrackedData {
 
 impl Collector {
     fn new() -> Arc<Self> {
-        let (async_gc_notifier, async_gc_receiver) = crossbeam::bounded(1);
+        let (async_gc_notifier, async_gc_receiver) = channel::bounded(1);
 
         let res = Arc::new(Self {
             gc_lock: Mutex::default(),
@@ -274,7 +274,7 @@ impl Collector {
         // We send a channel to the drop thread and wait for it to respond
         // This has the effect of synchronizing this thread with the drop thread
 
-        let (sender, receiver) = crossbeam::bounded(1);
+        let (sender, receiver) = channel::bounded(1);
         let drop_msg = DropMessage::SyncUp(sender);
         {
             self.dropper

--- a/src/concurrency/chunked_ll.rs
+++ b/src/concurrency/chunked_ll.rs
@@ -170,7 +170,7 @@ impl<T> ChunkedLinkedList<T> {
 
     pub fn insert(&self, v: Arc<T>) -> CLLItem<T> {
         loop {
-            if let Ok(idx) = self.free_entries.pop() {
+            if let Some(idx) = self.free_entries.pop() {
                 let chunk = unsafe { &*idx.0 };
                 let slot = &chunk.values[idx.1];
 


### PR DESCRIPTION
They need to be updated in sync so the dynqueue implementations
for crossbeam types continue to work.

Resolves #57