### PR TITLE
Use no-std-compat to transition to no-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,10 @@ shredder_derive = { git = "https://github.com/Others/shredder_derive.git" }
 #shredder_derive = { path = "../shredder_derive" }
 stable_deref_trait = "1.1"
 
+[dependencies.no-std-compat]
+version = "0.4.1"
+features = [ "alloc", "compat_hash", "compat_sync", "compat_macros" ]
+
 [dev-dependencies]
 paste = "1.0"
 rand = "0.7.3"
@@ -35,5 +39,6 @@ trybuild = "1.0"
 #debug = true
 
 [features]
-default = []
+default = [ "std" ] # Default to using the std
+std = [ "no-std-compat/std" ]
 nightly-features = []

--- a/src/atomic.rs
+++ b/src/atomic.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 use std::mem;
+use std::prelude::v1::*;
 use std::ptr::drop_in_place;
 use std::sync::atomic::{AtomicPtr, Ordering};
 use std::sync::Arc;

--- a/src/collector/alloc.rs
+++ b/src/collector/alloc.rs
@@ -1,6 +1,7 @@
 use std::alloc::{alloc, dealloc, Layout};
 use std::mem::{self, ManuallyDrop};
 use std::panic::UnwindSafe;
+use std::prelude::v1::*;
 use std::ptr;
 
 use crate::collector::InternalGcRef;

--- a/src/collector/collect_impl.rs
+++ b/src/collector/collect_impl.rs
@@ -1,3 +1,4 @@
+use std::prelude::v1::*;
 use std::sync::atomic::Ordering;
 
 use crossbeam::deque::Injector;

--- a/src/collector/data.rs
+++ b/src/collector/data.rs
@@ -1,3 +1,4 @@
+use std::prelude::v1::*;
 use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 use std::sync::Arc;
 

--- a/src/collector/dropper.rs
+++ b/src/collector/dropper.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 use std::panic::catch_unwind;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -1,3 +1,4 @@
+use std::prelude::v1::*;
 mod alloc;
 mod collect_impl;
 mod data;

--- a/src/collector/trigger.rs
+++ b/src/collector/trigger.rs
@@ -1,4 +1,5 @@
 use parking_lot::Mutex;
+use std::prelude::v1::*;
 
 // TODO(issue): https://github.com/Others/shredder/issues/8
 const DEFAULT_ALLOCATION_TRIGGER_PERCENT: f32 = 0.75;

--- a/src/concurrency/atomic_protection.rs
+++ b/src/concurrency/atomic_protection.rs
@@ -1,3 +1,4 @@
+use std::prelude::v1::*;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::thread::yield_now;
 

--- a/src/concurrency/chunked_ll.rs
+++ b/src/concurrency/chunked_ll.rs
@@ -1,4 +1,5 @@
 use std::mem::{self, MaybeUninit};
+use std::prelude::v1::*;
 use std::ptr;
 use std::sync::atomic::{AtomicPtr, AtomicUsize, Ordering};
 use std::sync::Arc;

--- a/src/concurrency/lockout.rs
+++ b/src/concurrency/lockout.rs
@@ -1,3 +1,4 @@
+use std::prelude::v1::*;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,9 @@
     clippy::module_name_repetitions, // Sometimes clear naming calls for repetition
     clippy::multiple_crate_versions  // There is no way to easily fix this without modifying our dependencies
 )]
+#![no_std]
+
+extern crate no_std_compat as std;
 
 #[macro_use]
 extern crate crossbeam;
@@ -69,6 +72,8 @@ pub mod wrappers;
 
 use std::cell::RefCell;
 use std::sync::{Mutex, RwLock};
+
+use std::prelude::v1::*;
 
 use crate::collector::COLLECTOR;
 

--- a/src/marker/gc_deref.rs
+++ b/src/marker/gc_deref.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 /// A marker trait that marks that this data can be stored in a `DerefGc`
 ///
 /// `T` can be `GcDeref` only if it is deeply immutable through a `&T`. This is because it's

--- a/src/marker/gc_safe.rs
+++ b/src/marker/gc_safe.rs
@@ -1,5 +1,6 @@
 use std::hash::{Hash, Hasher};
 use std::ops::{Deref, DerefMut};
+use std::prelude::v1::*;
 
 /// A marker trait that marks that data can be scanned in the background by the garbage collector.
 ///

--- a/src/r.rs
+++ b/src/r.rs
@@ -2,6 +2,7 @@ use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
+use std::prelude::v1::*;
 
 use crate::marker::{GcDeref, GcDrop, GcSafe};
 use crate::{Finalize, Scan, Scanner};

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -1,5 +1,6 @@
 use crate::collector::InternalGcRef;
 use crate::marker::GcSafe;
+use std::prelude::v1::*;
 
 /// A trait capturing the ability of data to be scanned for references to data in a `Gc`.
 ///

--- a/src/smart_ptr/deref_gc.rs
+++ b/src/smart_ptr/deref_gc.rs
@@ -1,3 +1,5 @@
+use std::prelude::v1::*;
+
 #[cfg(feature = "nightly-features")]
 use std::{marker::Unsize, ops::CoerceUnsized};
 

--- a/src/smart_ptr/gc.rs
+++ b/src/smart_ptr/gc.rs
@@ -5,6 +5,7 @@ use std::cmp::Ordering;
 use std::fmt::{self, Debug, Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::Deref;
+use std::prelude::v1::*;
 use std::sync;
 use std::sync::atomic;
 #[cfg(feature = "nightly-features")]

--- a/src/std_impls/collections.rs
+++ b/src/std_impls/collections.rs
@@ -3,6 +3,7 @@ use crate::{Finalize, Scan, Scanner};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::hash::BuildHasher;
 use std::mem::forget;
+use std::prelude::v1::*;
 use std::ptr::read;
 
 // For pretty much all simple collections, the collection inherets the properites of what it contains

--- a/src/std_impls/mod.rs
+++ b/src/std_impls/mod.rs
@@ -7,6 +7,7 @@ mod wrap_types;
 mod test {
     use std::cell::Cell;
     use std::panic::catch_unwind;
+    use std::prelude::v1::*;
     use std::sync::{Mutex, RwLock};
 
     use crate::collector::{get_mock_handle, InternalGcRef};

--- a/src/std_impls/value_types.rs
+++ b/src/std_impls/value_types.rs
@@ -1,4 +1,5 @@
 use std::collections::hash_map::RandomState;
+use std::prelude::v1::*;
 use std::ptr::drop_in_place;
 use std::time::{Duration, Instant};
 
@@ -46,6 +47,7 @@ sync_value_type!(RandomState);
 #[cfg(test)]
 mod test {
     use std::mem::forget;
+    use std::prelude::v1::*;
     use std::time::Instant;
 
     use crate::Finalize;

--- a/src/std_impls/wrap_types.rs
+++ b/src/std_impls/wrap_types.rs
@@ -1,5 +1,6 @@
 use crate::marker::{GcDeref, GcDrop, GcSafe};
 use crate::{Finalize, Scan, Scanner};
+use std::prelude::v1::*;
 
 use std::cell::{Cell, RefCell};
 use std::sync::{Arc, Mutex, RwLock, TryLockError};

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -1,6 +1,7 @@
 use std::cell::{BorrowError, BorrowMutError, RefCell};
 use std::fmt::{self, Debug, Formatter};
 use std::ops::{Deref, DerefMut};
+use std::prelude::v1::*;
 use std::sync::{self, TryLockError};
 
 use crate::{GcGuard, Scan};


### PR DESCRIPTION
This would close #21 - allowing Shredder to be used in `no-std` environments.

This uses the [no-std-compat](https://crates.io/crates/no-std-compat) crate to provide an easy transition. Mutexes and RwLocks are provided by the [spin](https://crates.io/crates/spin) crate. A user can get the no-std version of shredder by disabling the `std` feature.

One caveat to be aware of: debug prints, and error prints are replaced with no-ops. This might cause errors to go un-reported. An item of future work might be to find a way to make those assertions useful in a no-std environment.