### PR TITLE
Refactor the collector to use reference counting

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ crossbeam = "0.8.1"
 dynqueue = { version = "0.3.0", features = ["crossbeam-queue"] }
 log = "0.4.14"
 once_cell = "1.8"
+num_cpus = "1.0"
 parking_lot = "0.11.2"
 rayon = "1.5"
 rental = "0.5.6"
@@ -25,14 +26,15 @@ shredder_derive = "0.2.0"
 #shredder_derive = { git = "https://github.com/Others/shredder_derive.git" }
 #shredder_derive = { path = "../shredder_derive" }
 stable_deref_trait = "1.2"
+thread_local = "1.1"
 
 [dev-dependencies]
 paste = "1.0"
 rand = "0.8.3"
 trybuild = "1.0"
 
-#[profile.release]
-#debug = true
+[profile.release]
+debug = true
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ of the data has unpredictable cycles in it. (So Arc would not be appropriate.)
 - guarded access: accessing `Gc` data requires acquiring a guard (although you can use `DerefGc` in many cases to avoid this)
 - multiple collectors: only a single global collector is supported
 - can't handle `Rc`/`Arc`: requires all `Gc` objects have straightforward ownership semantics
-- collection optimized for speed, not memory use: `Gc` and internal metadata is small, but there is bloat during collection (will fix!)
 - no no-std support: The collector requires threading and other `std` features (will fix!)
 
 Getting Started

--- a/src/collector/alloc.rs
+++ b/src/collector/alloc.rs
@@ -203,7 +203,7 @@ impl GcAllocation {
         }
     }
 
-    pub fn scan<F: FnMut(InternalGcRef)>(&self, callback: F) {
+    pub fn scan<F: FnMut(&InternalGcRef)>(&self, callback: F) {
         unsafe {
             let mut scanner = Scanner::new(callback);
             let to_scan = &*self.scan_ptr;

--- a/src/collector/data.rs
+++ b/src/collector/data.rs
@@ -1,7 +1,8 @@
-use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
 use crate::collector::alloc::GcAllocation;
+use crate::collector::ref_cnt::GcRefCount;
 use crate::concurrency::lockout::{Lockout, LockoutProvider};
 use crate::Scan;
 
@@ -12,9 +13,8 @@ pub struct GcData {
     pub(crate) lockout: Lockout,
     /// have we started deallocating this piece of data yet?
     pub(crate) deallocated: AtomicBool,
-    // During what collection was this last marked?
-    //     0 if this is a new piece of data
-    pub(crate) last_marked: AtomicU64,
+    // reference count
+    pub(crate) ref_cnt: GcRefCount,
     /// a wrapper to manage (ie deallocate) the underlying allocation
     pub(crate) underlying_allocation: GcAllocation,
 }
@@ -26,38 +26,7 @@ impl LockoutProvider for Arc<GcData> {
 }
 
 impl GcData {
-    pub fn scan_ptr(&self) -> *const dyn Scan {
+    pub(crate) fn scan_ptr(&self) -> *const dyn Scan {
         self.underlying_allocation.scan_ptr
-    }
-}
-
-/// There is one `GcHandle` per `Gc<T>`. We need this metadata for collection
-#[derive(Debug)]
-pub struct GcHandle {
-    /// what data is backing this handle
-    pub(crate) underlying_data: UnderlyingData,
-    // During what collection was this last found in a piece of GcData?
-    //     0 if this is a new piece of data
-    pub(crate) last_non_rooted: AtomicU64,
-}
-
-#[derive(Debug)]
-pub enum UnderlyingData {
-    Fixed(Arc<GcData>),
-    DynamicForAtomic(Arc<AtomicPtr<GcData>>),
-}
-
-impl UnderlyingData {
-    // Safe only if called when the data is known to be live, and you know atomics can't be modified
-    // (Basically only okay to call in the collector itself)
-    #[inline]
-    pub unsafe fn with_data<F: FnOnce(&GcData)>(&self, f: F) {
-        match self {
-            Self::Fixed(data) => f(&*data),
-            Self::DynamicForAtomic(ptr) => {
-                let arc_ptr = ptr.load(Ordering::Relaxed);
-                f(&*arc_ptr)
-            }
-        }
     }
 }

--- a/src/collector/dropper.rs
+++ b/src/collector/dropper.rs
@@ -3,44 +3,47 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 use std::thread::spawn;
 
-use crossbeam::channel::{self, SendError, Sender};
-use parking_lot::RwLock;
-use rayon::iter::IntoParallelRefIterator;
-use rayon::iter::ParallelIterator;
+use crossbeam::channel::{self, Receiver, SendError, Sender};
 
 use crate::collector::GcData;
+use crate::concurrency::cross_thread_buffer::CrossThreadBuffer;
+
+type DropBuffer = CrossThreadBuffer<Arc<GcData>>;
 
 pub(crate) struct BackgroundDropper {
-    sender: Sender<DropMessage>,
+    // TODO: This would probably be marginally more efficient with non-channel based synchronization
+    drop_message_sender: Sender<DropMessage>,
+    buffer_recycler: Receiver<DropBuffer>,
 }
 
 pub(crate) enum DropMessage {
     /// Signals the `BackgroundDropper` to deallocate the following data (possibly running some destructor)
-    DataToDrop(RwLock<Vec<Arc<GcData>>>),
+    DataToDrop(DropBuffer),
     /// Indicates to the `BackgroundDropper` that it should sync up with the calling code
     SyncUp(Sender<()>),
 }
 
 impl BackgroundDropper {
+    const RECYCLING_CHANNEL_SIZE: usize = 1;
+
     pub fn new() -> Self {
-        let (sender, receiver) = channel::unbounded();
+        let (drop_message_sender, drop_message_retriever) = channel::unbounded();
+        let (recycling_sender, recycling_receiver) = channel::bounded(Self::RECYCLING_CHANNEL_SIZE);
 
         // The drop thread deals with doing all the Drops this collector needs to do
         spawn(move || {
             // An Err value means the stream will never recover
-            while let Ok(drop_msg) = receiver.recv() {
+            while let Ok(drop_msg) = drop_message_retriever.recv() {
                 match drop_msg {
-                    DropMessage::DataToDrop(to_drop) => {
-                        let to_drop = to_drop.read();
-
+                    DropMessage::DataToDrop(mut to_drop) => {
                         // NOTE: It's important that all data is correctly marked as deallocated before we start
-                        to_drop.par_iter().for_each(|data| {
+                        to_drop.par_for_each(|data| {
                             // Mark this data as in the process of being deallocated and unsafe to access
                             data.deallocated.store(true, Ordering::SeqCst);
                         });
 
                         // Then run the drops if needed
-                        to_drop.par_iter().for_each(|data| {
+                        to_drop.par_for_each(|data| {
                             let underlying_allocation = data.underlying_allocation;
                             let res = catch_unwind(move || unsafe {
                                 underlying_allocation.deallocate();
@@ -49,20 +52,41 @@ impl BackgroundDropper {
                                 eprintln!("Gc background drop failed: {:?}", e);
                             }
                         });
+
+                        // Then clear and recycle the buffer
+                        to_drop.clear();
+                        // ignore recycling failures
+                        let recycling_error = recycling_sender.try_send(to_drop);
+                        if let Err(e) = recycling_error {
+                            error!("Error recycling drop buffer {:?}", e);
+                        }
                     }
                     DropMessage::SyncUp(responder) => {
                         if let Err(e) = responder.send(()) {
-                            eprintln!("Gc background syncup failed: {:?}", e);
+                            error!("Gc background syncup failed: {:?}", e);
                         }
                     }
                 }
             }
         });
 
-        Self { sender }
+        Self {
+            drop_message_sender,
+            buffer_recycler: recycling_receiver,
+        }
     }
 
     pub fn send_msg(&self, msg: DropMessage) -> Result<(), SendError<DropMessage>> {
-        self.sender.send(msg)
+        self.drop_message_sender.send(msg)
+    }
+
+    pub fn get_buffer(&self) -> DropBuffer {
+        self.buffer_recycler.try_recv().unwrap_or_default()
+    }
+}
+
+impl Default for BackgroundDropper {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/src/collector/ref_cnt.rs
+++ b/src/collector/ref_cnt.rs
@@ -1,0 +1,92 @@
+use std::sync::atomic::{AtomicI64, Ordering};
+
+#[derive(Debug)]
+pub struct GcRefCount {
+    // `total_handles` = count_positive + count_negative
+    // `count_positive` is always >= the actual count >= 0
+    // At the beginning of every collection we recalculate `count_positive`
+    count_positive: AtomicI64,
+    // `count_negative` is always <= 0
+    count_negative: AtomicI64,
+
+    // Handles found in the current collection
+    found_internally: AtomicI64,
+}
+
+impl GcRefCount {
+    pub fn new(starting_count: i64) -> Self {
+        let s = Self {
+            count_positive: AtomicI64::new(starting_count),
+            count_negative: AtomicI64::new(0),
+            found_internally: AtomicI64::new(0),
+        };
+        s.override_mark_as_rooted();
+
+        s
+    }
+
+    pub fn prepare_for_collection(&self) {
+        // Ordering = relaxed, as this is protected by the collection mutex
+        self.found_internally.store(0, Ordering::Relaxed);
+
+        // `Ordering::Acquire` to sequence with the `Release` in `dec_count`
+        let negative = self.count_negative.swap(0, Ordering::Acquire);
+        // `Ordering::Acquire` to sequence with the `Release` in `inc_count`
+        let fixed_positive = self.count_positive.fetch_add(negative, Ordering::Acquire);
+
+        // If enabled, double check that we're adhering to the invariant
+        debug_assert!(fixed_positive >= 0);
+    }
+
+    pub fn found_once_internally(&self) {
+        // Ordering = relaxed, as this is protected by the collection mutex
+        self.found_internally.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn is_rooted(&self) -> bool {
+        // Due to the count invariant, this can never be less than the actual count
+        // Ordering = Acquire for the same reason as `prepare_for_collection`
+        let actual_count_plus_n = self.count_positive.load(Ordering::Acquire);
+        // Ordering = Relaxed, as this is protected by the collection mutex
+        let found_internally = self.found_internally.load(Ordering::Relaxed);
+
+        if actual_count_plus_n > found_internally {
+            // If n = 0, then `actual_count > found_internally` so we know we're rooted
+            // If n > 0, then we may or may not be rooted, but it's safe to assume we are
+            return true;
+        }
+        // In this case `actual_count + n <= found_internally`
+        // This implies `actual_count <= found_internally`
+        // So we found at least as many handles as actually exist, so this data must not be rooted
+        false
+    }
+
+    const ROOT_OVERRIDE_VALUE: i64 = -(1 << 60);
+
+    pub fn override_mark_as_rooted(&self) {
+        // Ordering = relaxed, as this is protected by the collection mutex
+        self.found_internally
+            .store(Self::ROOT_OVERRIDE_VALUE, Ordering::Relaxed);
+    }
+
+    pub fn was_overriden_as_rooted(&self) -> bool {
+        self.found_internally.load(Ordering::Relaxed) == Self::ROOT_OVERRIDE_VALUE
+    }
+
+    pub fn inc_count(&self) {
+        // `Ordering::Release` to sequence with the `Acquire` in `prepare_for_collection`
+        self.count_positive.fetch_add(1, Ordering::Release);
+    }
+
+    pub fn dec_count(&self) {
+        // `Ordering::Release` to sequence with the `Acquire` in `prepare_for_collection`
+        self.count_negative.fetch_sub(1, Ordering::Release);
+    }
+
+    pub fn snapshot_ref_count(&self) -> i64 {
+        let positive = self.count_positive.load(Ordering::Acquire);
+        let negative = self.count_negative.load(Ordering::Acquire);
+
+        positive + negative
+    }
+}

--- a/src/concurrency/chunked_ll.rs
+++ b/src/concurrency/chunked_ll.rs
@@ -48,14 +48,9 @@ impl<T> Chunk<T> {
         if self.next.is_null() {
             self.iter_this(f);
         } else {
-            rayon::join(
-                || self.iter_this(f),
-                || {
-                    let next = unsafe { &*self.next };
+            let next = unsafe { &*self.next };
 
-                    next.par_iter_rest(f)
-                },
-            );
+            rayon::join(|| self.iter_this(f), || next.par_iter_rest(f));
         }
     }
 
@@ -197,6 +192,7 @@ impl<T> ChunkedLinkedList<T> {
         }
     }
 
+    #[allow(dead_code)]
     pub fn remove(&self, cll_item: &CLLItem<T>) {
         let chunk = unsafe { &*cll_item.from };
 

--- a/src/concurrency/cross_thread_buffer.rs
+++ b/src/concurrency/cross_thread_buffer.rs
@@ -1,0 +1,38 @@
+use rayon::iter::{IntoParallelRefMutIterator, ParallelBridge, ParallelIterator};
+use std::cell::RefCell;
+use thread_local::ThreadLocal;
+
+pub(crate) struct CrossThreadBuffer<T: Send> {
+    buffers: ThreadLocal<RefCell<Vec<T>>>,
+}
+
+impl<T: Send> CrossThreadBuffer<T> {
+    pub fn new() -> Self {
+        Self {
+            buffers: ThreadLocal::with_capacity(num_cpus::get()),
+        }
+    }
+
+    pub fn push(&self, item: T) {
+        let tlb = self.buffers.get_or_default();
+        tlb.borrow_mut().push(item);
+    }
+
+    pub fn clear(&mut self) {
+        for v in self.buffers.iter_mut() {
+            v.get_mut().clear();
+        }
+    }
+
+    pub fn par_for_each<F: Fn(&mut T) + Send + Sync>(&mut self, f: F) {
+        self.buffers.iter_mut().par_bridge().for_each(|vec| {
+            vec.borrow_mut().par_iter_mut().for_each(|mut x| f(&mut x));
+        })
+    }
+}
+
+impl<T: Send> Default for CrossThreadBuffer<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/concurrency/lockout.rs
+++ b/src/concurrency/lockout.rs
@@ -4,7 +4,8 @@ use std::sync::Arc;
 use parking_lot::Condvar;
 use parking_lot::Mutex;
 
-const EXCLUSIVE_SIGNPOST: u64 = !0;
+const UNSAFE_EXCLUSIVE_SIGNPOST: u64 = !0;
+const EXCLUSIVE_SIGNPOST: u64 = UNSAFE_EXCLUSIVE_SIGNPOST - 1;
 
 /// The Lockout mechanism is used internally. It's basically just a `RwLock` that doesn't support
 /// blocking on reads. It also has a `LockoutProvider` interface that eases sharing the guards
@@ -25,13 +26,13 @@ impl Lockout {
         }
     }
 
-    pub fn get_warrant<P: LockoutProvider>(provider: P) -> Warrant<P> {
+    pub fn take_warrant<P: LockoutProvider>(provider: P) -> Warrant<P> {
         let lockout = provider.provide();
 
         let starting_count = lockout.count.load(Ordering::SeqCst);
 
         // Fast path, where the count is not SIGNPOSTED
-        if starting_count != EXCLUSIVE_SIGNPOST {
+        if starting_count < EXCLUSIVE_SIGNPOST {
             let swap_result = lockout.count.compare_exchange(
                 starting_count,
                 starting_count + 1,
@@ -48,7 +49,7 @@ impl Lockout {
         loop {
             let value = lockout.count.load(Ordering::SeqCst);
 
-            if value == EXCLUSIVE_SIGNPOST {
+            if value >= EXCLUSIVE_SIGNPOST {
                 lockout.lockout_condvar.wait(&mut guard);
             } else {
                 let swap_result = lockout.count.compare_exchange(
@@ -67,7 +68,9 @@ impl Lockout {
         }
     }
 
-    pub fn get_exclusive_warrant<P: LockoutProvider>(provider: P) -> Option<ExclusiveWarrant<P>> {
+    pub fn try_take_exclusive_warrant<P: LockoutProvider>(
+        provider: P,
+    ) -> Option<ExclusiveWarrant<P>> {
         let lockout = provider.provide();
 
         let swap_result = lockout.count.compare_exchange(
@@ -77,11 +80,49 @@ impl Lockout {
             Ordering::SeqCst,
         );
 
-        if swap_result.is_ok() {
-            Some(ExclusiveWarrant { provider })
-        } else {
-            None
+        match swap_result {
+            Ok(_) => Some(ExclusiveWarrant { provider }),
+            Err(_) => None,
         }
+    }
+
+    // Unsafe: only safe if paired with `try_release_exclusive_access_unsafe`
+    pub unsafe fn try_take_exclusive_access_unsafe<P: LockoutProvider>(provider: &P) -> bool {
+        let lockout = provider.provide();
+
+        let swap_result = lockout.count.compare_exchange(
+            0,
+            UNSAFE_EXCLUSIVE_SIGNPOST,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        );
+
+        swap_result.is_ok()
+    }
+
+    // Unsafe: you must guarantee that this is either paired with your `try_take_exclusive_access_unsafe`
+    // call. Otherwise, you may be releasing someone else's exclusive access
+    //
+    // in shredder only the collector uses this method for this reason
+    pub unsafe fn try_release_exclusive_access_unsafe<P: LockoutProvider>(provider: &P) {
+        let lockout = provider.provide();
+
+        let _guard = lockout.lockout_mutex.lock();
+
+        // It's okay if this fails, since we only are trying to relase if it is taken
+        let _ = lockout.count.compare_exchange(
+            UNSAFE_EXCLUSIVE_SIGNPOST,
+            0,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        );
+
+        lockout.lockout_condvar.notify_all();
+    }
+
+    pub fn unsafe_exclusive_access_taken<P: LockoutProvider>(provider: &P) -> bool {
+        let lockout = provider.provide();
+        lockout.count.load(Ordering::SeqCst) == UNSAFE_EXCLUSIVE_SIGNPOST
     }
 }
 
@@ -92,21 +133,9 @@ pub struct Warrant<P: LockoutProvider> {
 
 impl<P: LockoutProvider> Drop for Warrant<P> {
     fn drop(&mut self) {
-        loop {
-            let lockout = self.provider.provide();
-
-            let count = lockout.count.load(Ordering::SeqCst);
-            assert!(count > 0 && count != EXCLUSIVE_SIGNPOST);
-            let swap_result = lockout.count.compare_exchange(
-                count,
-                count - 1,
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            );
-            if swap_result.is_ok() {
-                return;
-            }
-        }
+        let lockout = self.provider.provide();
+        // Safe to assume we can subtract, because the warrant promises we incremented once
+        lockout.count.fetch_sub(1, Ordering::SeqCst);
     }
 }
 
@@ -120,13 +149,16 @@ impl<P: LockoutProvider> Drop for ExclusiveWarrant<P> {
         let lockout = self.provider.provide();
 
         let _guard = lockout.lockout_mutex.lock();
-        let swap_result = lockout.count.compare_exchange(
+
+        let res = lockout.count.compare_exchange(
             EXCLUSIVE_SIGNPOST,
             0,
             Ordering::SeqCst,
             Ordering::SeqCst,
         );
-        assert!(swap_result.is_ok());
+
+        debug_assert!(res.is_ok());
+
         lockout.lockout_condvar.notify_all();
     }
 }
@@ -151,22 +183,22 @@ mod test {
     #[test]
     fn warrant_prevents_exclusive_warrant() {
         let lockout = Arc::new(Lockout::new());
-        let _warrant = Lockout::get_warrant(lockout.clone());
-        let exclusive_warrant_option = Lockout::get_exclusive_warrant(lockout);
+        let _warrant = Lockout::take_warrant(lockout.clone());
+        let exclusive_warrant_option = Lockout::try_take_exclusive_warrant(lockout);
         assert!(exclusive_warrant_option.is_none());
     }
 
     #[test]
     fn exclusive_warrant_works_by_itself() {
         let lockout = Arc::new(Lockout::new());
-        let exclusive_warrant_option = Lockout::get_exclusive_warrant(lockout);
+        let exclusive_warrant_option = Lockout::try_take_exclusive_warrant(lockout);
         assert!(exclusive_warrant_option.is_some());
     }
 
     #[test]
     fn multiple_warrants() {
         let lockout = Arc::new(Lockout::new());
-        let _warrant_1 = Lockout::get_warrant(lockout.clone());
-        let _warrant_2 = Lockout::get_warrant(lockout);
+        let _warrant_1 = Lockout::take_warrant(lockout.clone());
+        let _warrant_2 = Lockout::take_warrant(lockout);
     }
 }

--- a/src/concurrency/mod.rs
+++ b/src/concurrency/mod.rs
@@ -1,3 +1,4 @@
 pub mod atomic_protection;
 pub mod chunked_ll;
+pub mod cross_thread_buffer;
 pub mod lockout;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@
 //! - guarded access: accessing `Gc` data requires acquiring a guard (although you can use `DerefGc` in many cases to avoid this)
 //! - multiple collectors: only a single global collector is supported
 //! - can't handle `Rc`/`Arc`: requires all `Gc` objects have straightforward ownership semantics
-//! - collection optimized for speed, not memory use: `Gc` and internal metadata is small, but there is bloat during collection (will fix!)
 //! - no no-std support: The collector requires threading and other `std` features (will fix!)
 
 #![cfg_attr(feature = "nightly-features", feature(unsize, coerce_unsized))]
@@ -34,6 +33,7 @@
     clippy::redundant_clone,
     clippy::use_self,
     rust_2018_idioms
+    // TODO: Enable `unreachable_pub`
 )]
 // But I don't care about these ones
 #![allow(
@@ -42,7 +42,7 @@
     clippy::explicit_deref_methods,  // Sometimes calling `deref` directly is clearer
     clippy::module_name_repetitions, // Sometimes clear naming calls for repetition
     clippy::multiple_crate_versions, // There is no way to easily fix this without modifying our dependencies
-    proc_macro_back_compat           // Hide this error until we have a path forward. FIXME: issue
+    proc_macro_back_compat           // Hide this error until we have a path forward. TODO: issue
 )]
 
 #[macro_use]

--- a/src/marker/gc_drop.rs
+++ b/src/marker/gc_drop.rs
@@ -1,8 +1,8 @@
 /// A marker trait that the destructor of this data can be safely run in the background thread
 ///
 /// Basically it asserts three things
-/// 1) Any thread can drop this data (It is `Send`, or `!Send` purely because it contains a `Gc`, or
-/// it is `!Send` but you know that any thread dropping this data is safe.)
+/// 1) Any thread can drop this data (It is `Send`, or `!Send` purely because it contains a `!Send`
+/// `Gc<X>`, or it is `!Send` but you know that any thread dropping this data is safe.)
 /// 2) This data does not own a `AtomicGc` or `DerefGc`
 /// 3) This data is `'static`, or you can guarantee that it's safe to drop it after its lifetime
 /// has ended.

--- a/src/plumbing.rs
+++ b/src/plumbing.rs
@@ -15,7 +15,7 @@ pub fn check_gc_drop<T: GcDrop>(_: &T) {}
 #[inline(always)]
 pub fn check_gc_safe<T: GcSafe>(_: &T) {}
 
-// FIXME: This macro can be removed once we have overlapping marker traits
+// TODO: This macro can be removed once we have overlapping marker traits
 //        (https://github.com/rust-lang/rust/issues/29864)
 /// A `Send + 'static` type can be safely marked as `GcSafe`, and this macro eases that
 /// implementation

--- a/src/r.rs
+++ b/src/r.rs
@@ -73,7 +73,7 @@ unsafe impl<'a, T: ?Sized> GcDeref for R<'a, T> where T: GcDeref {}
 
 unsafe impl<'a, T: ?Sized> GcSafe for RMut<'a, T> {}
 // unsafe impl<'a, T: ?Sized> !GcDrop for RMut<'a, T> {}
-// FIXME: Kinda a subtle impl, not sure if it's correct
+// This is counter intuitive, but safe (because you can't get a mutable reference from a &RMut)
 unsafe impl<'a, T: ?Sized> GcDeref for RMut<'a, T> where T: GcDeref {}
 
 unsafe impl<'a, T: ?Sized> Scan for R<'a, T> {
@@ -160,8 +160,6 @@ where
         raw.hash(state);
     }
 }
-
-// TODO: Ord, PartialOrd
 
 impl<'a, T: ?Sized> PartialEq for R<'a, T>
 where

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -111,13 +111,12 @@ unsafe impl<T: Scan + Sized + 'static> ToScan for T {
 /// Scanner is a struct used to manage the scanning of data, sort of analogous to `Hasher`
 /// Usually you will only care about this while implementing `Scan`
 pub struct Scanner<'a> {
-    pub(crate) scan_callback: Box<dyn FnMut(InternalGcRef) + 'a>,
+    pub(crate) scan_callback: Box<dyn FnMut(&InternalGcRef) + 'a>,
 }
 
-#[allow(clippy::unused_self)]
 impl<'a> Scanner<'a> {
     #[must_use]
-    pub(crate) fn new<F: FnMut(InternalGcRef) + 'a>(callback: F) -> Self {
+    pub(crate) fn new<F: FnMut(&InternalGcRef) + 'a>(callback: F) -> Self {
         Self {
             scan_callback: Box::new(callback),
         }
@@ -130,7 +129,7 @@ impl<'a> Scanner<'a> {
     }
 
     #[inline]
-    pub(crate) fn add_internal_handle(&mut self, gc_ref: InternalGcRef) {
+    pub(crate) fn add_internal_handle(&mut self, gc_ref: &InternalGcRef) {
         (self.scan_callback)(gc_ref);
     }
 }

--- a/src/smart_ptr/deref_gc.rs
+++ b/src/smart_ptr/deref_gc.rs
@@ -145,7 +145,7 @@ unsafe impl<T: Scan + GcDeref + ?Sized> Scan for DerefGc<T> {
     #[allow(clippy::inline_always)]
     #[inline(always)]
     fn scan(&self, scanner: &mut Scanner<'_>) {
-        scanner.add_internal_handle(self.backing_handle.clone());
+        scanner.add_internal_handle(&self.backing_handle);
     }
 }
 
@@ -291,11 +291,11 @@ where
 }
 
 #[cfg(test)]
+#[allow(clippy::eq_op)]
 mod test {
     use crate::DerefGc;
 
     #[test]
-    #[allow(clippy::eq_op)]
     fn test_eq() {
         let a = DerefGc::new(1);
         let b = DerefGc::new(1);

--- a/src/std_impls/mod.rs
+++ b/src/std_impls/mod.rs
@@ -19,7 +19,7 @@ mod test {
     unsafe impl GcSafe for MockGc {}
     unsafe impl Scan for MockGc {
         fn scan(&self, scanner: &mut Scanner<'_>) {
-            (scanner.scan_callback)(self.handle.clone());
+            (scanner.scan_callback)(&self.handle);
         }
     }
 


### PR DESCRIPTION
This is around a ~4x speedup, but required a lot of code changes.
In terms of public API, only `AtomicGc` has a significant diff.
(The old API would still work, but the changes make it work
more efficently with the new internals.)